### PR TITLE
fix: remove HA and aiohttp from manifest requirements

### DIFF
--- a/custom_components/sensus_analytics/manifest.json
+++ b/custom_components/sensus_analytics/manifest.json
@@ -1,14 +1,11 @@
 {
   "domain": "sensus_analytics",
   "name": "Sensus Analytics Integration",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "documentation": "https://github.com/zestysoft/sensus_analytics_integration",
   "dependencies": [],
   "codeowners": ["@zestysoft"],
-  "requirements": [
-    "aiohttp>=3.13.3",
-    "homeassistant>=2026.3.4"
-  ],
+  "requirements": [],
   "iot_class": "cloud_polling",
   "config_flow": true
 }


### PR DESCRIPTION
## Summary
- Remove `homeassistant` and `aiohttp` from `manifest.json` `requirements` — these are provided by HA core and should not be listed there
- HA was trying to `pip install homeassistant>=2026.3.4` on top of itself, causing an `orjson` version conflict that prevented the integration from loading
- Bump version to 1.7.5

## Test plan
- [ ] Deploy to HA and confirm `sensus_analytics` loads without errors in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)