### PR TITLE
Remove redundant aiohttp requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-aiohttp==3.13.3
 homeassistant==2026.3.4


### PR DESCRIPTION
## Summary
- remove the direct aiohttp pin from dev requirements
- rely on homeassistant==2026.3.4 to install its compatible aiohttp==3.13.3

## Verification
- python3.14 venv: pip install --dry-run -r requirements.txt

This addresses the failing Dependabot aiohttp PRs (#75 and #76), which conflict with Home Assistant's own aiohttp pin.