### PR TITLE
Bump Home Assistant to 2026.4.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-homeassistant==2026.3.4
+homeassistant==2026.4.4


### PR DESCRIPTION
## Summary
- bump dev requirement from homeassistant==2026.3.4 to homeassistant==2026.4.4
- this now resolves aiohttp==3.13.5 through Home Assistant's own pin

## Verification
- python3.14 venv: pip install --dry-run -r requirements.txt
- python3.14 venv: pip install black isort bandit pylint -r requirements.txt
- black --check custom_components/sensus_analytics
- isort --check-only custom_components/sensus_analytics
- bandit -r custom_components/sensus_analytics
- pylint custom_components/sensus_analytics

PyPI latest stable Home Assistant is 2026.4.4; 2026.5.0b0 is a beta.